### PR TITLE
feat: Convert to CommonJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
-import fs from 'fs'
-import path from 'path'
-import ipRangeCheck from 'ip-range-check'
-import { fileURLToPath } from 'url'
+const fs = require('fs')
+const path = require('path')
+const ipRangeCheck = require('ip-range-check')
 
 class CloudflareIPManager {
   ipRanges = { v4: [], v6: [] }
@@ -91,9 +90,9 @@ class CloudflareIPManager {
   }
 }
 
-export default class ExpressCloudflareMiddleware {
+class ExpressCloudflareMiddleware {
   constructor(options = {}) {
-    const defaultPath = path.dirname(fileURLToPath(import.meta.url)) + '/data'
+    const defaultPath = path.join(__dirname, '/data')
     const defaultOptions = {
       updateInterval: 3600000,
       strict: true,
@@ -141,7 +140,7 @@ export default class ExpressCloudflareMiddleware {
       const cfConnectingIP = req.headers['cf-connecting-ip']
       if (this.options.updateClientIP && cfConnectingIP) {
         Object.defineProperty(req, 'ip', {
-          get: function() {
+          get: function () {
             return cfConnectingIP || req.ip
           },
           configurable: true
@@ -156,3 +155,5 @@ export default class ExpressCloudflareMiddleware {
     }
   }
 }
+
+module.exports = ExpressCloudflareMiddleware

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "express-cloudflare-middleware",
   "version": "1.0.2",
-  "type": "module",
+  "type": "commonjs",
   "description": "Express middleware to validate Cloudflare IP addresses",
-  "main": "index.mjs",
+  "main": "index.js",
   "homepage": "https://github.com/dmitry/express-cloudflare-middleware",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Using ESM forces all consumers of this library to also use ESM. An alternative would be to use a build tool like Rollup to compile different targets, but that adds unnecessary complexity for the time being.